### PR TITLE
Set LC_ALL before launching ES

### DIFF
--- a/repository.gamestarter/game.retroarch/addon.start
+++ b/repository.gamestarter/game.retroarch/addon.start
@@ -89,6 +89,12 @@ case $1 in
   ;;
   "emulationstation")  
       echo "EmulationStation [ADDON] :: Launch EmulationStation (See process output in emulationstation_debug.log)" >>  $LOG_FILE_ES
+      # Set locale
+      if ( [ -z "$LANG" ] || [ -z "$LC_CTYPE" ] ) && [ -z "$LC_ALL" ]
+      then
+            echo "EmulationStation [ADDON] :: Set LC_ALL=C" >> $LOG_FILE_ES
+            export LC_ALL="C"
+      fi
       # /storage/emulators/temp/retroarch/temp/retroarch --no-splash --ignore-gamelist
       "$ADDON_ES_DIR/game.emulationstation-$PROJECT" --no-splash &>  $LOG_FILE_ES_DEBUG
   ;;


### PR DESCRIPTION
EmulationStation fails to launch unless locale category is set.

terminate called after throwing an instance of 'std::runtime_error'
  what():  locale::facet::_S_create_c_locale name not valid
Aborted

This PR will export LC_ALL=C before launching EmulationStation unless a locale category is already set.